### PR TITLE
Fix the issue of not uploading zip files successfully

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -15,6 +15,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with SSID.  If not, see <http://www.gnu.org/licenses/>.
 =end
 
+require 'zip'
+
 class AssignmentsController < ApplicationController
   before_action { |controller|
     if params[:course_id]

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -81,10 +81,7 @@ class AssignmentsController < ApplicationController
       return render action: "new" unless @assignment.save
       
       if !params[:assignment]["file"].nil?
-        if (params[:assignment]["file"].content_type == "application/x-zip-compressed" || 
-          params[:assignment]["file"].content_type == "application/x-zip-compressed-compressed" ||
-          params[:assignment]["file"].content_type == "application/x-zip-compressed")
-
+        if (is_valid_zip?(params[:assignment]["file"].content_type, params[:assignment]["file"].path))
           self.start_upload(@assignment, params[:assignment]["file"])
           redirect_to course_assignments_url(@course), notice: 'Assignment was successfully created.'
         else
@@ -108,7 +105,7 @@ class AssignmentsController < ApplicationController
   def update
     @assignment = Assignment.find(params[:id])
     
-    if !(params[:assignment].nil? or params[:assignment]["file"].content_type != "application/x-zip-compressed")
+    if !(params[:assignment].nil? or or !(is_valid_zip?(params[:assignment]["file"].content_type, params[:assignment]["file"].path)))
       self.start_upload(@assignment, params[:assignment]["file"])
       redirect_to course_assignments_url(@course), notice: 'File was successfully uploaded.'
     else
@@ -138,4 +135,28 @@ class AssignmentsController < ApplicationController
       # Launch java program to process submissions
       SubmissionsHandler.process_submissions(submissions_path, assignment)
   end
+
+  def is_valid_zip?(memeType, filePath)
+    print filePath
+    print memeType 
+    if memeType == "application/x-zip-compressed" || 
+      memeType == "application/zip-compressed" ||
+      memeType == "application/zip"
+      return true;
+    else
+      return is_opened_as_zip?(filePath)
+    end
+  end
+
+  def is_opened_as_zip?(path)
+    print path
+    zip = Zip::File.open(path)
+    true
+  rescue StandardError
+    false
+  ensure
+    zip.close if zip
+  end
 end
+
+


### PR DESCRIPTION
**Summary**

This PR aims to solve the issue #31, where several zip files were unable to get uploaded despite not being corrupted.

**Problem**

Upon debugging the app, it was found out that the app was only recognizing zip files whose mime type was 
- application/x-zip-compressed (when creating and/or updating assignment)
- application/x-zip-compressed-compressed (only when creating assignment)

while zip files with different mime types such as application/zip were getting rejected.

**Solution**
A combination of 2 solutions have been implemented to counter the above issue.

1) Add more mime types
More mime types such as application/zip have been included in the code so that zip files with these mime types which were previously unrecognized as zip files will now no longer be rejected. However, a point to take note here is that files with mime type, application/octet-stream, can be either a zip or rar file. As such, replying simply on the mime type may not be sufficient which brings the need for the second solution (stated below).

2) Use of rubyzip library
A function has been written to check whether a file is zip or not based on whether the rubyzip library is able to open and extract the file. This check is used when a zip file does not meet the updated specified mime types stated in the above solution but could still be a zip file. This check takes a bit more time than the above solution and hence is used only after a file fails the above solution to further verify that the file is indeed not a zip file.

**Testing performed**
Several files (including zip files with different mime types) were uploaded and checked whether were they getting accepted or rejected accurately. 
