### PR TITLE
Fix the issue of uncreated directory when extracting zip files

### DIFF
--- a/lib/submissions_handler.rb
+++ b/lib/submissions_handler.rb
@@ -88,7 +88,7 @@ module SubmissionsHandler
         # Create Directory
         FileUtils.mkdir_p(File.dirname(f_path))
         # Extract files into the file path
-        zip_file.extract(f, f_path)
+        zip_file.extract(f, f_path) unless File.exist?(f_path)
 
         # Reject files that passed the extension test but might be a binary file in disguise
         # if f.file? filepath

--- a/lib/submissions_handler.rb
+++ b/lib/submissions_handler.rb
@@ -83,8 +83,12 @@ module SubmissionsHandler
       # isdirectory or filter by accepted file extension
       if !f.file? or accepted_formats.include? File.extname(f.name)
         upload_log << %Q{[#{Time.now.in_time_zone}] Extracting #{f.name}}
-        filepath = File.join(upload_dir, f.name)
-        zip_file.extract(f, filepath)
+        # Obtain File Path
+        f_path = File.join(upload_dir, f.name)
+        # Create Directory
+        FileUtils.mkdir_p(File.dirname(f_path))
+        # Extract files into the file path
+        zip_file.extract(f, f_path)
 
         # Reject files that passed the extension test but might be a binary file in disguise
         # if f.file? filepath


### PR DESCRIPTION
This PR aims to resolve the issue of uncreated directory when WinZip files are uploaded into SSID.

**Name of Error:**
No such file or directory @ rb_sysopen

**Reason for Error:**
WinZip files (usually zip files which were packaged in the windows OS) were generating this error while compressed files (zip files that were packaged in a linux OS) were not generating any errors as our code was not taking into account of some of the characteristics of an uploaded WinZip file. While compressed folder displays its files in the original hierarchy of folders and subfolders, WinZip would display its files as a single file list and would list the folder or subfolder in which the file exists.

The app did not checked or created the directory when the zip file was a WinZip zip file.

**Resolution:**
The extraction method has been changed so that the directory would be created first regardless of the zip file type.

**Testing Performed**
WinZip files were uploaded into the app and their results were analyzed to check whether were they getting processed correctly.