### PR TITLE
Add github issue auto labeller action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  auto_label:
+    runs-on: ubuntu-latest
+    name: Automatic Github Issue Labeller
+    steps:
+    - name: Label Step
+      uses: larrylawl/Auto-Github-Issue-Labeller@main
+      with:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        REPOSITORY: ${{github.repository}}
+        DELTA: "365"
+        CONFIDENCE: "2"
+        FEATURE: "enhancement"
+        BUG: "bug"
+        DOCS: "documentation"
+        VERSION: "v1.0"


### PR DESCRIPTION
Hi! I'm Larry, a student who took CS4248 under Prof Min. As liaised with Prof Min, this PR starts up the github action to automatically label your github issues as bug , enhancement,  documentation, or skips labelling when unconfident using NLP. More details can be found in our repository [here](https://github.com/larrylawl/auto-github-issue-labeller-action).

Feel free to change the options within main.yml. In particular, I've set `DELTA` to be `365` so that the action will label all issues a year back; hopefully the model labels most of the unlabelled issues in this repository. If this action led to any bugs, feel free to post an issue in our repository. 

Thank you!