### PR TITLE
comfirmed_as_not_plagarism, Response to Issue 22

### DIFF
--- a/app/controllers/submission_similarities_controller.rb
+++ b/app/controllers/submission_similarities_controller.rb
@@ -144,6 +144,28 @@ class SubmissionSimilaritiesController < ApplicationController
     redirect_to assignment_submission_similarity_url(@assignment, @submission_similarity)
   end
 
+   # PUT /students/1/submission_similarities/1/confirm_as_not_plagiarism
+  def confirm_as_not_plagiarism
+    @submission_similarity = SubmissionSimilarity.find(params["submission_similarity_id"])
+    @submission_similarity.status = SubmissionSimilarity::STATUS_CONFIRMED_AS_NOT_PLAGIARISM
+    if @submission_similarity.save
+      mark_student_as_not_guilty(@submission_similarity.submission1, @submission_similarity)
+      mark_student_as_not_guilty(@submission_similarity.submission2, @submission_similarity)
+      SubmissionLog.create { |sl|
+        sl.submission_similarity = @submission_similarity
+        sl.submission = @submission_similarity.submission1
+        sl.marker = @user
+        sl.log_type = SubmissionLog::TYPE_PAIR_CONFIRM_AS_NOT_PLAGIARISM
+      }
+      SubmissionLog.create { |sl|
+        sl.submission_similarity = @submission_similarity
+        sl.submission = @submission_similarity.submission2
+        sl.marker = @user
+        sl.log_type = SubmissionLog::TYPE_PAIR_CONFIRM_AS_NOT_PLAGIARISM
+      }
+    end
+    redirect_to assignment_submission_similarity_url(@assignment, @submission_similarity)
+  end
   # PUT /students/1/submission_similarities/1/suspect_as_plagiarism
   def suspect_as_plagiarism
     @submission_similarity = SubmissionSimilarity.find(params["submission_similarity_id"])

--- a/app/models/submission_log.rb
+++ b/app/models/submission_log.rb
@@ -22,12 +22,14 @@ class SubmissionLog < ActiveRecord::Base
   TYPE_PAIR_UNMARK_AS_PLAGIARISM = 2
   TYPE_STUDENT_MARK_AS_GUILTY = 3
   TYPE_STUDENT_MARK_AS_NOT_GUILTY = 4
+  TYPE_PAIR_CONFIRM_AS_NOT_PLAGIARISM = 5
   TYPE_TEMPLATE_STRINGS = [
     "Suspected as plagiarism with submission by ",
     "Confirmed as plagiarism with submission by ",
     "Unmarked as plagiarism with submission by ",
     "Marked as guilty of plagiarism of submission by ",
-    "Unmarked as guilty of plagiarism of submission by "
+    "Unmarked as guilty of plagiarism of submission by ",
+    "Marked as checked with no plagiarism with submission by "
   ]
 
   belongs_to :marker, class_name: "User"

--- a/app/models/submission_similarity.rb
+++ b/app/models/submission_similarity.rb
@@ -20,10 +20,12 @@ class SubmissionSimilarity < ActiveRecord::Base
   STATUS_NOT_PLAGIARISM = 0
   STATUS_CONFIRMED_AS_PLAGIARISM = 1
   STATUS_SUSPECTED_AS_PLAGIARISM = 2
+  STATUS_CONFIRMED_AS_NOT_PLAGIARISM = 3
   STATUS_STRINGS = [
     "",
     "Confirmed Plagiarism",
-    "Suspected of Plagiarism"
+    "Suspected of Plagiarism",
+    "Checked as not plagiarism"
   ]
 
   belongs_to :assignment

--- a/app/views/submission_similarities/show.html.erb
+++ b/app/views/submission_similarities/show.html.erb
@@ -26,12 +26,15 @@
   </div>
   <div class="mark_as_suspicious">
     <% if @submission_similarity.status == SubmissionSimilarity::STATUS_NOT_PLAGIARISM %>
-      <%= button_to "Confirm these similarities as plagiarism", assignment_submission_similarity_confirm_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Confirm these similarities as plagiarism?"} %> <%= link_to "or mark these similarities as suspicious...", assignment_submission_similarity_suspect_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Mark these similarities as suspicious?"} %> 
+      <p><%= link_to "Mark these similarities as suspicious", assignment_submission_similarity_suspect_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Mark these similarities as suspicious?"} %> or  <%= link_to "Confirm these similarities as not plagiarism", assignment_submission_similarity_confirm_as_not_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Confirm these similarities as not plagiarism?"} %> or  <%= link_to "Confirm these similarities as plagiarism", assignment_submission_similarity_confirm_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Confirm these similarities as plagiarism?"} %></p>
     <% elsif @submission_similarity.status == SubmissionSimilarity::STATUS_SUSPECTED_AS_PLAGIARISM %>
-      <p>These similarities were marked as suspicious. <%= button_to "Remove suspicion", assignment_submission_similarity_unmark_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Remove suspicion of plagiarism?"} %> <%= button_to "Confirm as plagiarism", assignment_submission_similarity_confirm_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Confirm these similarities as plagiarism?"} %></p>
+      <p>These similarities were marked as suspicious. <%= link_to "Remove suspicion", assignment_submission_similarity_unmark_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Remove suspicion of plagiarism?"} %> or <%= link_to "Confirm as plagiarism", assignment_submission_similarity_confirm_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Confirm these similarities as plagiarism?"} %> or <%= link_to "Confirm these similarities as not plagiarism", assignment_submission_similarity_confirm_as_not_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Confirm these similarities as not plagiarism?"} %></p>
+    <% elsif @submission_similarity.status == SubmissionSimilarity::STATUS_CONFIRMED_AS_PLAGIARISM %>
+      <p>These similarities were confirmed as plagiarism. <%= link_to "Remove", assignment_submission_similarity_unmark_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Remove confirmation as plagiarism?"} %> or <%= link_to "Confirm these similarities as not plagiarism", assignment_submission_similarity_confirm_as_not_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Confirm these similarities as not plagiarism?"} %></p>
     <% elsif %>
-      <p>These similarities were confirmed as plagiarism. <%= link_to "Remove", assignment_submission_similarity_unmark_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Remove confirmation as plagiarism?"} %></p>
-    <% end %>
+      <p>These similarities were checked as not plagiarism. <%= link_to "Unchecked", assignment_submission_similarity_unmark_as_plagiarism_url(@assignment, @submission_similarity), :method => :put, data: {confirm: "Marked as unchecked submission?"} %></p>
+
+      <% end %>
   </div>
   <% if @submission_similarity.status == SubmissionSimilarity::STATUS_CONFIRMED_AS_PLAGIARISM %>
   <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ SSID::Application.routes.draw do
       put "confirm_as_plagiarism" => "submission_similarities#confirm_as_plagiarism"
       put "suspect_as_plagiarism" => "submission_similarities#suspect_as_plagiarism"
       put "unmark_as_plagiarism" => "submission_similarities#unmark_as_plagiarism"
+      put "confirm_as_not_plagiarism" => "submission_similarities#confirm_as_not_plagiarism"
     end
 
     resources :submissions do


### PR DESCRIPTION
I just created a new PR as my solution to Issue 22, adding a new status called "Confirmed as not plagiarism"

The related status changed are "mark student as not guilty", student is not guilty again because we have checked that they are not plagiarize but this will raise another issue for the status of guilty which should be case sensitive. To illustrate, student's guilty status should be related to different submission instead of setting as a global variable. 