### PR TITLE
Issue 116 loading users page

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,6 +36,8 @@ class Admin::UsersController < ApplicationController
   # GET /admin/users
   def index
     @admins = User.where(is_admin: true)
+
+    # users don't belong to any course
     @loners = User.all - User.joins(:memberships) - @admins
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,13 +35,8 @@ class Admin::UsersController < ApplicationController
 
   # GET /admin/users
   def index
-    @courses = Course.all
     @admins = User.where(is_admin: true)
-    @staff = Hash[@courses.collect { |c| [c.id, c.staff] }]
-    @teaching_assistants = Hash[@courses.collect { |c| [c.id, c.teaching_assistants] }]
-    @students = Hash[@courses.collect { |c| [c.id, c.students] }]
-    @loners = User.all - UserCourseMembership.all.collect { |m| m.user } - @admins
-    @guests = Hash[@courses.collect { |c| [c.id, c.guests] }]
+    @loners = User.all - User.joins(:memberships) - @admins
   end
 
   # GET /admin/users/new

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -118,8 +118,8 @@ class Admin::UsersController < ApplicationController
 
     # Check for errors and render view
     if @the_user.errors.empty? and @the_user.save
-      if @existing_user
-        redirect_to admin_users_url, notice: "User was successfully added 
+      if @existing_user or not @course.nil?
+        redirect_to course_users_url(@course), notice: "User was successfully added 
         to #{@course.code}."
       else 
         redirect_to admin_users_url, notice: 'User was successfully created.'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,10 +25,11 @@ class ApplicationController < ActionController::Base
     def authorize
       # get user and respective membership
       @user = User.find_by_id(session[:user_id]) 
-      @membership = UserCourseMembership.find_by_user_id(@user.id)
-      
+
       unless @user
         redirect_to login_url, notice: "Please log in"
+      else
+        @membership = UserCourseMembership.find_by_user_id(@user.id)
       end
     end
   

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -53,69 +53,6 @@
 
 </div>
 
-<% @courses.each { |course| %>
-<div class="course_users_section">
-  <header class="course_user_header">
-    <h5><%= course.code %> <%= course.name %></h5>
-    <%= link_to image_tag("person_add_blue_24dp.svg", size: "28", alt: "Add #{course.code} User"), new_admin_user_url+"?course_id=#{course.id}", { 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => "Add #{course.code} User" } %>
-  </header>
-
-  <% unless (@staff[course.id] + @teaching_assistants[course.id] + @students[course.id] + @guests[course.id]).empty? %>
-  <table>
-    <thead>
-      <tr>
-        <th>Full Name</th>
-        <th class="id_col">Login</th>
-        <th class="id_col">ID/ Hash</th>
-        <th class="role_col">Role</th>
-        <th class="actions_col">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% (@staff[course.id] + @teaching_assistants[course.id] + @students[course.id] + @guests[course.id]).each { |user| %>
-        <tr>
-          <td> 
-            <% if course.membership_for_user(user).role == UserCourseMembership::ROLE_GUEST %> 
-              <%= "--" %> 
-            <% else %> 
-              <%= user.full_name || "--" %>
-            <% end %>
-          </td>
-          <td>
-            <% if course.membership_for_user(user).role == UserCourseMembership::ROLE_GUEST %> 
-              <%= "--" %> 
-            <% else %> 
-              <%= user.name || "--" %>
-            <% end %>
-          </td>
-          <td><%= user.id_string %></td>
-          <td><%= course.role_string_for_user(user) %></td>
-          <td>
-            <div class="dropdown">
-              <a data-toggle="dropdown" id="userDropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
-                <%= image_tag("more_vert_black_24dp.svg", alt: "User Menu Dropdown")%>        
-              </a>
-              <ul class="dropdown-menu" aria-labelledby="userDropdownMenuLink">
-                <li><%= link_to "Edit", edit_admin_user_url(user)+"?course_id=#{course.id}", class: "dropdown-item" %></li>
-                <% if course.membership_for_user(user).role != UserCourseMembership::ROLE_STUDENT %>
-                  <li>
-                    <% url = admin_user_url(user)+"?course_id=#{course.id}" %>
-                    <%= button_tag 'Remove', class: "dropdown-item", data: { 'bs-toggle' => "modal", 'bs-target' => "#removeUserModal", 'bs-url' => "#{url}" } %>
-                  </li>                
-                <% end %>
-              </ul>
-            </div>
-          </td>
-        </tr>
-      <% } %>
-    </tbody>
-  </table>
-  <% end %>
-
-
-</div>
-<% } %>
-
 <% unless @loners.empty? %>
 <div class="lone_users_section">
 
@@ -161,9 +98,5 @@
   <%= render partial: "site/modal", locals: { modal: @modal }%>
 </div>
 
-<div class="modal fade" id="removeUserModal" tabindex="-1" role="dialog" aria-hidden="true">
-  <% @modal = SiteModal.new("Remove User", "The user will be removed from the course. Are you sure?", { :name => "OK", :method => :delete }) %>
-  <%= render partial: "site/modal", locals: { modal: @modal }%>
-</div>
 
 <%= javascript_include_tag "site_modal.js" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -26,16 +26,28 @@
         <td><%= user.id_string %></td>
         <td><%= @course.role_string_for_user(user) %></td>
         <td>
-          <% if @course.role_string_for_user(user) != "Student" %>
           <div class="dropdown">
+          <!-- Dropdown actions are available in 2 cases:
+            1. current logged-in user is an admin as admin has privilege to edit all users' info. 
+            2. Shown record is a non-student record   
+          -->
+          <% if @user.is_admin || @course.membership_for_user(user).role != UserCourseMembership::ROLE_STUDENT %>
             <a data-toggle="dropdown" id="userDropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
               <%= image_tag("more_vert_black_24dp.svg", alt: "User Menu Dropdown")%>                  
             </a>
             <ul class="dropdown-menu" aria-labelledby="userDropdownMenuLink">
-              <li><%= link_to "Remove", admin_user_url(user)+"?course_id=#{@course.id}", method: "delete", data: {confirm: "Do you want to confirm remove user from course?"}, class: "dropdown-item" %></li>
+              <% if @user.is_admin %>
+                <li><%= link_to "Edit", edit_admin_user_url(user)+"?course_id=#{@course.id}", class: "dropdown-item" %></li>
+              <% end %>                  
+              <% if @course.membership_for_user(user).role != UserCourseMembership::ROLE_STUDENT %>
+                <li> 
+                  <% url = admin_user_url(user)+"?course_id=#{@course.id}" %>
+                  <%= button_tag 'Remove', class: "dropdown-item", data: { 'bs-toggle' => "modal", 'bs-target' => "#removeUserModal", 'bs-url' => "#{url}" } %>
+                </li>
+              <% end %>
             </ul>
-          </div>
-          <% end %>
+          <% end %> 
+          </div>          
         </td>
       </tr>
     <% } %>
@@ -43,3 +55,10 @@
 </table>
 
 </div>
+
+<div class="modal fade" id="removeUserModal" tabindex="-1" role="dialog" aria-hidden="true">
+  <% @modal = SiteModal.new("Remove User", "The user will be removed from the course. Are you sure?", { :name => "OK", :method => :delete }) %>
+  <%= render partial: "site/modal", locals: { modal: @modal }%>
+</div>
+
+<%= javascript_include_tag "site_modal.js" %>


### PR DESCRIPTION
This PR aims to reduce the load of Users page by managing course users individually in each course and managing other users (admin, users without course membership) in Users page - logged in as admin.

It retains SSID's current behaviors for staff, teaching assistant (TA), and student users as below:
- Staff, TAs would be able to view Course Users page. 
- Staff would be able to create, and remove non-student users from the course users page.

Admin users would have the same privileges as staff users, plus editing users' info (e.g. login name, password) privilege. 

Users page

![Screenshot from 2022-03-15 12-07-59](https://user-images.githubusercontent.com/5399322/158304528-3c5ce8da-1861-4027-a1e1-4104f4957085.png)

Course users page

Logged-in as admin

Creating non-student user

![Screenshot from 2022-03-15 11-51-06](https://user-images.githubusercontent.com/5399322/158304611-c1fee3c4-e892-4d46-8a67-71e031e09d47.png)

![Screenshot from 2022-03-15 11-51-21](https://user-images.githubusercontent.com/5399322/158304641-2599d3e5-aab7-422b-982e-6e89837caf02.png)

Viewing

![Screenshot from 2022-03-15 11-51-48](https://user-images.githubusercontent.com/5399322/158304766-b8337921-b5fb-4067-a361-036977004be1.png)

Logged-in as teaching staff

Creating non-student user

![Screenshot from 2022-03-15 11-52-33](https://user-images.githubusercontent.com/5399322/158304702-c269da2d-93e7-4e31-9545-8b1f0d95f3bc.png)

![Screenshot from 2022-03-15 11-52-50](https://user-images.githubusercontent.com/5399322/158304790-881b9e5e-bd87-468f-8643-4a3eef249622.png)


