### PR TITLE
Exclude skeleton code

### DIFF
--- a/app/assets/images/square_01.svg
+++ b/app/assets/images/square_01.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#d3d3d3" class="bi bi-square-fill" viewBox="0 0 16 16">
+  <path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2z"/>
+</svg>

--- a/app/assets/images/square_02.svg
+++ b/app/assets/images/square_02.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFE55" class="bi bi-square-fill" viewBox="0 0 16 16">
+  <path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2z"/>
+</svg>

--- a/app/assets/javascripts/submission_similarities.js
+++ b/app/assets/javascripts/submission_similarities.js
@@ -43,11 +43,58 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
       startLine2 = parseInt(values[2]);
       endLine2 = parseInt(values[3]);
       $(checkBox).closest("tr").addClass("highlight");
-      for (lineIdx = _i = startLine1; startLine1 <= endLine1 ? _i <= endLine1 : _i >= endLine1; lineIdx = startLine1 <= endLine1 ? ++_i : --_i) {
-        $("div.submission1 li:eq(" + lineIdx + ")").addClass("highlight");
+
+      // differentiate colors
+      let skeletonLines = $(checkBox).closest("input.skeleton-lines").val().split(/\s/)
+      let skeletonIdxS1 = []
+      let skeletonIdxS2 = []
+      for (i = startLine1; i <= endLine1; ++i) {
+        skeletonIdxS1.push(false);
       }
+
+      for (i = startLine2; i <= endLine2; ++i) {
+        skeletonIdxS2.push(false);
+      }
+      
+      skeletonLines.forEach((skeletonLine) => {
+        lineInfo = skeletonLine.split("_")
+        skeletonStartLine1 = parseInt(lineInfo[0])
+        skeletonEndLine1 = parseInt(lineInfo[1])
+        skeletonStartLine2 = parseInt(lineInfo[2])
+        skeletonEndLine2 = parseInt(lineInfo[3])
+
+        for (i = 0; i < skeletonIdxS1.length; ++i) {
+          if (skeletonStartLine1 <= i+startLine1 && i+startLine1 <= skeletonEndLine1) {
+            skeletonIdxS1[i] = true;
+          }
+        }
+
+        for (i = 0; i < skeletonIdxS2.length; ++i) {
+          if (skeletonStartLine2 <= i+startLine2 && i+startLine2 <= skeletonEndLine2) {
+            skeletonIdxS2[i] = true;
+          }
+        }                
+      })
+
+
+
+
+
+
+      for (lineIdx = _i = startLine1; startLine1 <= endLine1 ? _i <= endLine1 : _i >= endLine1; lineIdx = startLine1 <= endLine1 ? ++_i : --_i) {
+        if (skeletonIdxS1[lineIdx - startLine1] == false) {
+          $("div.submission1 li:eq(" + lineIdx + ")").addClass("highlight");
+        } else {
+          $("div.submission1 li:eq(" + lineIdx + ")").addClass("skeleton-highlight");
+        }
+      }
+
       for (lineIdx = _j = startLine2; startLine2 <= endLine2 ? _j <= endLine2 : _j >= endLine2; lineIdx = startLine2 <= endLine2 ? ++_j : --_j) {
-        $("div.submission2 li:eq(" + lineIdx + ")").addClass("highlight");
+        if (skeletonIdxS2[lineIdx - startLine2] == false) {
+          $("div.submission2 li:eq(" + lineIdx + ")").addClass("highlight");
+        } else {
+          $("div.submission2 li:eq(" + lineIdx + ")").addClass("skeleton-highlight");
+        }
       }
     };
   
@@ -63,16 +110,18 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
         $(checkBox).closest("tr").removeClass("highlight");
         for (lineIdx = _i = startLine1; startLine1 <= endLine1 ? _i <= endLine1 : _i >= endLine1; lineIdx = startLine1 <= endLine1 ? ++_i : --_i) {
           $("div.submission1 li:eq(" + lineIdx + ")").removeClass("highlight");
+          $("div.submission1 li:eq(" + lineIdx + ")").removeClass("skeleton-highlight");
         }
         for (lineIdx = _j = startLine2; startLine2 <= endLine2 ? _j <= endLine2 : _j >= endLine2; lineIdx = startLine2 <= endLine2 ? ++_j : --_j) {
           $("div.submission2 li:eq(" + lineIdx + ")").removeClass("highlight");
+          $("div.submission2 li:eq(" + lineIdx + ")").removeClass("skeleton-highlight");
         }
       }
     };
   
     SubmissionSimilarity.toggleRowHighlight = function(el) {
       var inputNode;
-      inputNode = $(el).find("input");
+      inputNode = $(el).find("input.checkbox");
       if (inputNode.is(":checked")) {
         inputNode.prop("checked", false);
         SubmissionSimilarity.unhighlightLines(inputNode);
@@ -87,7 +136,7 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
       headerInputNode = $(el);
       $("table.lines tbody tr").each(function() {
         var inputNode;
-        inputNode = $(this).find("input");
+        inputNode = $(this).find("input.checkbox");
         if (headerInputNode.is(":checked") && !inputNode.is(":checked") || !headerInputNode.is(":checked") && inputNode.is(":checked")) {
           SubmissionSimilarity.toggleRowHighlight($(this));
         }
@@ -126,7 +175,7 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
         $("table.lines th.check_box_col").hover(
           function() {$("table.lines tbody tr").each(function() {
             var inputNode;
-            inputNode = $(this).find("input");
+            inputNode = $(this).find("input.checkbox");
             if (!inputNode.is(":checked")) {
               SubmissionSimilarity.highlightLines(inputNode);
             }
@@ -134,7 +183,7 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
           }, 
           function() {$("table.lines tbody tr").each(function() {
             var inputNode;
-            inputNode = $(this).find("input");
+            inputNode = $(this).find("input.checkbox");
             if (!inputNode.is(":checked")) {
               SubmissionSimilarity.unhighlightLines(inputNode);
             }

--- a/app/assets/stylesheets/submission_similarities.css.scss
+++ b/app/assets/stylesheets/submission_similarities.css.scss
@@ -71,6 +71,21 @@ body.submission_similarities_show {
       margin-bottom: $spacer * 0.75;
     }
 
+    div.submissions-legend {
+      margin-bottom: $spacer * 0.5;
+
+      ul {
+        list-style: none;
+        margin: $spacer*0.5 0;
+        padding: 0px;
+
+        li {
+          display: inline-block;
+          padding-left: $spacer * 0.5;
+        }
+      }
+    }
+
     pre {
       margin-top: 0px;
       border: 1px solid grey;
@@ -80,7 +95,7 @@ body.submission_similarities_show {
       }
 
       ol.linenums li.skeleton-highlight {
-        background-color: rgb(255, 255, 194);
+        background-color: rgb(211, 211, 211);
       }
     }
 

--- a/app/assets/stylesheets/submission_similarities.css.scss
+++ b/app/assets/stylesheets/submission_similarities.css.scss
@@ -48,7 +48,7 @@ body.submission_similarities_show {
     margin-top: $spacer * 0.75;
     margin-bottom: $spacer * 0.5;
   }
-  
+ 
   table {
     @extend .table;
     @extend .table-bordered;
@@ -76,7 +76,11 @@ body.submission_similarities_show {
       border: 1px solid grey;
 
       ol.linenums li.highlight {
-        background-color: rgb(255, 255, 140);
+        background-color: rgb(255, 254, 85);
+      }
+
+      ol.linenums li.skeleton-highlight {
+        background-color: rgb(255, 255, 194);
       }
     }
 

--- a/app/models/submission_similarity.rb
+++ b/app/models/submission_similarity.rb
@@ -55,4 +55,8 @@ class SubmissionSimilarity < ActiveRecord::Base
   def other_submission(student)
     (student == submission1.student) ? submission2 : submission1
   end
+
+  def similarity_mappings
+    SubmissionSimilarityMapping.where("submission_similarity_id = ? AND statement_count > 0", self.id)
+  end
 end

--- a/app/models/submission_similarity_mapping.rb
+++ b/app/models/submission_similarity_mapping.rb
@@ -17,6 +17,7 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
 
 class SubmissionSimilarityMapping < ActiveRecord::Base
   belongs_to :submission_similarity
+  has_many :submission_similarity_skeleton_mappings, :dependent => :delete_all, class_name: "SubmissionSimilaritySkeletonMapping"
 
   def line_range1
     (self.start_line1)..(self.end_line1)

--- a/app/models/submission_similarity_skeleton_mapping.rb
+++ b/app/models/submission_similarity_skeleton_mapping.rb
@@ -1,0 +1,4 @@
+class SubmissionSimilaritySkeletonMapping < ActiveRecord::Base
+  belongs_to :submission_similarity_mapping
+
+end

--- a/app/views/submission_similarities/show.html.erb
+++ b/app/views/submission_similarities/show.html.erb
@@ -39,12 +39,16 @@
       </tr>
     </thead>
     <tbody>
-      <% @submission_similarity.mappings.sort_by { |m| m.start_line1 }.each { |mapping| %>
+      <% @submission_similarity.similarity_mappings.sort_by { |m| m.start_line1 }.each { |mapping| %>
       <tr>
         <td>Lines <%= mapping.line_range1_string %></td>
         <td>Lines <%= mapping.line_range2_string %></td>
         <td class="num_statements_cell"><%= mapping.statement_count %></td>
-        <td><%= check_box_tag nil, mapping.line_ranges_html_value, false %></td>
+        <td><%= check_box_tag nil, mapping.line_ranges_html_value, false, { :class => "checkbox" } %></td>
+        <%= hidden_field_tag "skeleton_lines", mapping.submission_similarity_skeleton_mappings.collect { |s_mapping| 
+          s_mapping.start_line1.to_s + "_" + s_mapping.end_line1.to_s + "_" + s_mapping.start_line2.to_s + "_" + s_mapping.end_line2.to_s
+        }, { :class => "skeleton-lines" } 
+        %>
       </tr>
       <% } %>
     </tbody>

--- a/app/views/submission_similarities/show.html.erb
+++ b/app/views/submission_similarities/show.html.erb
@@ -72,6 +72,14 @@
 <% end %>
 
 <div class="submissions">
+  <div class="submissions-legend">
+    <strong>Line colors</strong>
+    <br>
+    <ul>
+      <li><%= image_tag("square_01.svg", size: "16", alt: "Skeleton code color")%> Skeleton code</li>
+      <li><%= image_tag("square_02.svg", size: "16", alt: "Submission code color")%> Submission code</li>
+    </ul>
+  </div>
   <div class="submission1">
     <h5>Submission by <%= @student1.id_string %> (<%= link_to "Log", assignment_submission_log_url(@assignment, @submission1) %>)</h5>
     <pre class="prettyprint linenums <%= @assignment.prettify_js_lang %>">

--- a/db/migrate/20220228074041_create_submission_similarity_skeleton_mappings.rb
+++ b/db/migrate/20220228074041_create_submission_similarity_skeleton_mappings.rb
@@ -1,0 +1,15 @@
+class CreateSubmissionSimilaritySkeletonMappings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :submission_similarity_skeleton_mappings do |t|
+      t.bigint :submission_similarity_mapping_id
+      t.integer :start_line1
+      t.integer :end_line1
+      t.integer :start_line2
+      t.integer :end_line2
+
+      t.timestamps
+    end
+
+    add_index :submission_similarity_skeleton_mappings, :submission_similarity_mapping_id, name: "on_submission_similarity_mapping_id"
+  end
+end

--- a/lib/java/PlagiarismDetection/src/pd/MySQLDB.java
+++ b/lib/java/PlagiarismDetection/src/pd/MySQLDB.java
@@ -222,7 +222,6 @@ public final class MySQLDB {
 			stmt.setString(7, dateTime);
 			stmt.setString(8, dateTime);
 
-			// System.out.println("SQL query: " + stmt.toString());
 			stmt.addBatch();
 		}
 		stmt.executeBatch();
@@ -286,7 +285,6 @@ public final class MySQLDB {
 						bMappingStatement.setString(6, dateTime);
 						bMappingStatement.setString(7, dateTime);
 
-						System.out.println("SQL query: " + bMappingStatement.toString());
 						bMappingStatement.addBatch();
 					}	
 				}

--- a/lib/java/PlagiarismDetection/src/pd/MySQLDB.java
+++ b/lib/java/PlagiarismDetection/src/pd/MySQLDB.java
@@ -36,7 +36,9 @@ public final class MySQLDB {
 	private static final String STUDENT_SELECT = "SELECT id FROM users WHERE id_string = ?";
 	private static final String RESULT_INSERT = "INSERT INTO submission_similarities(assignment_id, submission1_id, submission2_id, similarity_1_to_2, similarity_2_to_1, similarity, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 	private static final String CODE_INSERT = "INSERT INTO submissions(`lines`, assignment_id, student_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)";
-	private static final String MAPPING_INSERT = "INSERT INTO submission_similarity_mappings(submission_similarity_id, start_index1, end_index1, start_index2, end_index2, start_line1, end_line1, start_line2, end_line2, statement_count, is_plagiarism, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+	private static final String MAPPING_INSERT = "INSERT INTO submission_similarity_mappings(id, submission_similarity_id, start_index1, end_index1, start_index2, end_index2, start_line1, end_line1, start_line2, end_line2, statement_count, is_plagiarism, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+	private static final String MAPPING_MAX_ID_SELECT = "SELECT max(id) FROM submission_similarity_mappings";
+	private static final String SKELETON_MAPPING_INSERT = "INSERT INTO submission_similarity_skeleton_mappings(submission_similarity_mapping_id, start_line1, end_line1, start_line2, end_line2, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
 	private static MySQLDB instance = new MySQLDB();
 	private DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 	private Connection con;
@@ -219,6 +221,8 @@ public final class MySQLDB {
 			stmt.setFloat(6, Math.max(sim1To2, sim2To1));
 			stmt.setString(7, dateTime);
 			stmt.setString(8, dateTime);
+
+			// System.out.println("SQL query: " + stmt.toString());
 			stmt.addBatch();
 		}
 		stmt.executeBatch();
@@ -239,36 +243,74 @@ public final class MySQLDB {
 			ArrayList<Result> results) throws Exception {
 		String dateTime = dateFormat.format(new java.util.Date());
 		PreparedStatement stmt = con.prepareStatement(MAPPING_INSERT);
+		PreparedStatement bMappingStatement = con.prepareStatement(SKELETON_MAPPING_INSERT);
 
 		Iterator<Integer> idIterator = genIds.iterator();
 		Iterator<Result> resultIterator = results.iterator();
 
 		ArrayList<Mapping> mappings;
-		int id;
+		long mappingId = getCurrentMaxMappingId();
+		int submissionSimilarityId;;
 		while (idIterator.hasNext() || resultIterator.hasNext()) {
 
-			id = idIterator.next();
+			submissionSimilarityId = idIterator.next();
 			mappings = resultIterator.next().getCodeIndexMappings();
+			mappingId += 1;
 
 			for (Mapping m : mappings) {
-				stmt.setInt(1, id);
-				stmt.setInt(2, m.getStartIndex1());
-				stmt.setInt(3, m.getEndIndex1());
-				stmt.setInt(4, m.getStartIndex2());
-				stmt.setInt(5, m.getEndIndex2());
-				stmt.setInt(6, m.getStartLine1());
-				stmt.setInt(7, m.getEndLine1());
-				stmt.setInt(8, m.getStartLine2());
-				stmt.setInt(9, m.getEndLine2());
-				stmt.setInt(10, m.getMappedCountableStmtCount());
-				stmt.setBoolean(11, m.isPlagMapping());
-        stmt.setString(12, dateTime);
+				stmt.setLong(1, mappingId);
+				stmt.setInt(2, submissionSimilarityId);
+				stmt.setInt(3, m.getStartIndex1());
+				stmt.setInt(4, m.getEndIndex1());
+				stmt.setInt(5, m.getStartIndex2());
+				stmt.setInt(6, m.getEndIndex2());
+				stmt.setInt(7, m.getStartLine1());
+				stmt.setInt(8, m.getEndLine1());
+				stmt.setInt(9, m.getStartLine2());
+				stmt.setInt(10, m.getEndLine2());
+				stmt.setInt(11, m.getMappedCountableStmtCount());
+				stmt.setBoolean(12, m.isPlagMapping());
         stmt.setString(13, dateTime);
+        stmt.setString(14, dateTime);
 				stmt.addBatch();
+
+				// Update submissionSimilarityMappingId in skeleton mappings
+				List<SkeletonMapping> skeletonMappings = m.getSkeletonMappings();
+				if (skeletonMappings != null && skeletonMappings.size() > 0) {
+					for (SkeletonMapping bMapping : skeletonMappings) {
+						bMappingStatement.setLong(1, mappingId);
+						bMappingStatement.setInt(2, bMapping.getStartLine1());
+						bMappingStatement.setInt(3, bMapping.getEndLine1());
+						bMappingStatement.setInt(4, bMapping.getStartLine2());
+						bMappingStatement.setInt(5, bMapping.getEndLine2());
+						bMappingStatement.setString(6, dateTime);
+						bMappingStatement.setString(7, dateTime);
+
+						System.out.println("SQL query: " + bMappingStatement.toString());
+						bMappingStatement.addBatch();
+					}	
+				}
+
+				mappingId += 1;
 			}
 		}
 		stmt.executeBatch();
 		stmt.close();
+
+		bMappingStatement.executeBatch();
+		bMappingStatement.close();
+	}
+
+	private long getCurrentMaxMappingId() throws Exception {
+		long maxMappingId = 1L;
+		PreparedStatement statement = con.prepareStatement(MAPPING_MAX_ID_SELECT);
+		ResultSet resultSet = statement.executeQuery();
+		if (resultSet != null && resultSet.next()) {
+			maxMappingId = resultSet.getLong(1);
+		}
+
+		statement.close();
+		return maxMappingId;
 	}
 
 	private void connectionDB() throws Exception {

--- a/lib/java/PlagiarismDetection/src/pd/SimComparer.java
+++ b/lib/java/PlagiarismDetection/src/pd/SimComparer.java
@@ -289,6 +289,7 @@ public final class SimComparer {
 			TokenList bTokens,
 			HashMap<NGram, ArrayList<Integer>> bNGramIndices, int minMatch,
 			ArrayList<Mapping> tokenMappings) {
+		System.out.println("**************************************************************************************");
 
 		NGramList s1RegionNGrams;
 		TokenList s1RegionTokens;
@@ -338,11 +339,27 @@ public final class SimComparer {
 						bTokens, null, minMatch, bMappings);
 				mappedCountableStmt = m.getMappedCountableStmtCount();
 
+				System.out.println("Mapping is: " + m.toString());
 				for (Mapping b : bMappings) {
 					mappedCountableStmt -= b.getMappedCountableStmtCount();
+					System.out.println("Skeleton mapping is: " + b.toString());
 				}
 
 				if (mappedCountableStmt >= minMatch) {
+					// To exclude tokens found in skeleton code from similarity percentage later on
+					for (Mapping b : bMappings) {
+						int startIdxOfSkeletonInS1 = b.getStartIndex1() + m.getStartIndex1();
+						int endIdxOfSkeletonInS1 = b.getEndIndex1() + m.getStartIndex1();
+						int startIdxOfSkeletonInS2 = b.getStartIndex1() + m.getStartIndex2();
+						int endIdxOfSkeletonInS2 = b.getEndIndex1() + m.getStartIndex2();
+						s1Tokens.baseMarkRange(startIdxOfSkeletonInS1, endIdxOfSkeletonInS1);
+						s2Tokens.baseMarkRange(startIdxOfSkeletonInS2, endIdxOfSkeletonInS2);
+
+						System.out.println("Test skeleton mapping in S2: ");
+						System.out.println(String.format("Start line S2: %d || End line S2: %d", s2Tokens.get(startIdxOfSkeletonInS2).getCodeLine(), s2Tokens.get(endIdxOfSkeletonInS2).getCodeLine()));
+					}
+
+					m.setMappedCountableStmtCount(mappedCountableStmt);
 					s1Tokens.markRange(s1StartIndex, s1EndIndex);
 					s2Tokens.markRange(s2StartIndex, s2EndIndex);
 					m.setIsPlagMapping(true);

--- a/lib/java/PlagiarismDetection/src/pd/SimComparer.java
+++ b/lib/java/PlagiarismDetection/src/pd/SimComparer.java
@@ -70,18 +70,6 @@ public final class SimComparer {
 					computeSims(s2Tokens, s1Tokens, result);
 				}
 
-				System.out.println("DEBUG 03: " + s1.getID() + ", " + s2.getID());
-				List<Mapping> mappings = result.getTokenIndexMappings();
-				if (mappings != null) {
-					for(Mapping m : mappings) {
-						List<SkeletonMapping> bMappings = m.getSkeletonMappings();
-						if (bMappings != null) {
-							for(SkeletonMapping bMapping : bMappings) {
-								System.out.println("Skeleton mapping: " + bMapping.getStartLine1() + ", " + bMapping.getEndLine1() + " || " + bMapping.getStartLine2() + ", " + bMapping.getEndLine2());
-							}
-						}
-					}
-				}
 				results.add(result);
 
 				unmarkTokens(s1Tokens, s2Tokens, bTokens);
@@ -101,28 +89,8 @@ public final class SimComparer {
 
 	private void computeSims(TokenList s1Tokens, TokenList s2Tokens,
 			Result result) {
-		System.out.println("Test whether marking skeleton tokens has overlap");
-
-		if (s1Tokens.getMarkedBaseTokens() != null && s2Tokens.getMarkedBaseTokens() != null) {
-			int S1_countFromArray = 0;
-			int S2_countFromArray = 0;
-			for (Boolean b : s1Tokens.getMarkedBaseTokens()) {
-				if (b != null && b.equals(Boolean.TRUE)) {
-					S1_countFromArray++;
-				}
-			}
-
-			for (Boolean b : s2Tokens.getMarkedBaseTokens()) {
-				if (b != null && b.equals(Boolean.TRUE)) {
-					S2_countFromArray++;
-				}
-			}
-			// System.out.println(String.format("S1 array count: %d, S1 own count: %d", S1_countFromArray, s1Tokens.getBaseCount()));
-			// System.out.println(String.format("S2 array count: %d, S2 own count: %d", S2_countFromArray, s2Tokens.getBaseCount()));
-		}
 
 		if (s1Tokens.size() == s1Tokens.getBaseCount() || s2Tokens.size() == s2Tokens.getBaseCount()) {
-			System.out.println(String.format("One of the submission is same with skeleton, and ids: %s %s", result.getS1().getID(), result.getS2().getID()));
 			result.setSim2To1(0f);
 			result.setSim1To2(0f);
 			return;
@@ -333,7 +301,6 @@ public final class SimComparer {
 			TokenList bTokens,
 			HashMap<NGram, ArrayList<Integer>> bNGramIndices, int minMatch,
 			ArrayList<Mapping> tokenMappings) {
-		System.out.println("**************************************************************************************");
 
 		NGramList s1RegionNGrams;
 		TokenList s1RegionTokens;
@@ -383,11 +350,9 @@ public final class SimComparer {
 						bTokens, null, minMatch, bMappings);
 				mappedCountableStmt = m.getMappedCountableStmtCount();
 
-				System.out.println("Mapping is: " + m.toString());
 				List<SkeletonMapping> skeletonMappings = new ArrayList<>();
 				for (Mapping b : bMappings) {
 					mappedCountableStmt -= b.getMappedCountableStmtCount();
-					System.out.println("Skeleton mapping is: " + b.toString());
 
 					int startIdxOfSkeletonInS1 = b.getStartIndex1() + m.getStartIndex1();
 					int endIdxOfSkeletonInS1 = b.getEndIndex1() + m.getStartIndex1();
@@ -405,9 +370,6 @@ public final class SimComparer {
 					skeletonMapping.setEndLine2(s2Tokens.get(endIdxOfSkeletonInS2).getCodeLine());
 
 					skeletonMappings.add(skeletonMapping);
-
-					System.out.println("Test skeleton mapping in S2: ");
-					System.out.println(String.format("Start line S2: %d || End line S2: %d", s2Tokens.get(startIdxOfSkeletonInS2).getCodeLine(), s2Tokens.get(endIdxOfSkeletonInS2).getCodeLine()));
 				}
 
 				m.setMappedCountableStmtCount(mappedCountableStmt);

--- a/lib/java/PlagiarismDetection/src/pd/SimComparer.java
+++ b/lib/java/PlagiarismDetection/src/pd/SimComparer.java
@@ -358,7 +358,9 @@ public final class SimComparer {
 				m.setIsPlagMapping(true);
 			}
 
-			tokenMappings.add(m);
+			if (m.isPlagMapping()) {
+				tokenMappings.add(m);
+			}
 		}
 	}
 }

--- a/lib/java/PlagiarismDetection/src/pd/SimComparer.java
+++ b/lib/java/PlagiarismDetection/src/pd/SimComparer.java
@@ -89,8 +89,36 @@ public final class SimComparer {
 
 	private void computeSims(TokenList s1Tokens, TokenList s2Tokens,
 			Result result) {
-		result.setSim2To1((float) s2Tokens.getMarkCount() / s2Tokens.size());
-		result.setSim1To2((float) s1Tokens.getMarkCount() / s1Tokens.size());
+		System.out.println("Test whether marking skeleton tokens has overlap");
+
+		if (s1Tokens.getMarkedBaseTokens() != null && s2Tokens.getMarkedBaseTokens() != null) {
+			int S1_countFromArray = 0;
+			int S2_countFromArray = 0;
+			for (Boolean b : s1Tokens.getMarkedBaseTokens()) {
+				if (b != null && b.equals(Boolean.TRUE)) {
+					S1_countFromArray++;
+				}
+			}
+
+			for (Boolean b : s2Tokens.getMarkedBaseTokens()) {
+				if (b != null && b.equals(Boolean.TRUE)) {
+					S2_countFromArray++;
+				}
+			}
+			// System.out.println(String.format("S1 array count: %d, S1 own count: %d", S1_countFromArray, s1Tokens.getBaseCount()));
+			// System.out.println(String.format("S2 array count: %d, S2 own count: %d", S2_countFromArray, s2Tokens.getBaseCount()));
+		}
+
+		if (s1Tokens.size() == s1Tokens.getBaseCount() || s2Tokens.size() == s2Tokens.getBaseCount()) {
+			System.out.println(String.format("One of the submission is same with skeleton, and ids: %s %s", result.getS1().getID(), result.getS2().getID()));
+			result.setSim2To1(0f);
+			result.setSim1To2(0f);
+			return;
+		} 
+
+		result.setSim2To1((float) s2Tokens.getMarkCount() / (s2Tokens.size() - s2Tokens.getBaseCount()));
+		result.setSim1To2((float) s1Tokens.getMarkCount() / (s1Tokens.size() - s1Tokens.getBaseCount()));
+
 	}
 
 	private Submission getSkeletonCode(ArrayList<Submission> submissions) {

--- a/lib/java/PlagiarismDetection/src/pd/utils/Mappings/Mapping.java
+++ b/lib/java/PlagiarismDetection/src/pd/utils/Mappings/Mapping.java
@@ -17,6 +17,8 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
  
 package pd.utils.Mappings;
 
+import java.util.List;
+
 public class Mapping {
 
 	private int startIndex1, endIndex1, startIndex2, endIndex2;
@@ -24,6 +26,8 @@ public class Mapping {
 	private boolean isPlagMapping;
 
 	private int mappedCountableStatement, mappedNonCountableStatement;
+
+	private List<SkeletonMapping> skeletonMappings;
 
 	public boolean isPlagMapping() {
 		return isPlagMapping;
@@ -107,6 +111,14 @@ public class Mapping {
 
 	public void setIsPlagMapping(boolean value) {
 		isPlagMapping = value;
+	}
+
+	public List<SkeletonMapping> getSkeletonMappings() {
+		return skeletonMappings;
+	}
+
+	public void setSkeletonMappings(List<SkeletonMapping> skeletonMappings) {
+		this.skeletonMappings = skeletonMappings;
 	}
 
 	public Mapping(int startIndex1, int endIndex1, int startIndex2,

--- a/lib/java/PlagiarismDetection/src/pd/utils/Mappings/Mapping.java
+++ b/lib/java/PlagiarismDetection/src/pd/utils/Mappings/Mapping.java
@@ -33,37 +33,73 @@ public class Mapping {
 		return startIndex1;
 	}
 
+	public void setStartIndex1(int startIndex1) {
+		this.startIndex1 = startIndex1;
+	}
+
 	public int getEndIndex1() {
 		return endIndex1;
+	}
+
+	public void setEndIndex1(int endIndex1) {
+		this.endIndex1 = endIndex1;
 	}
 
 	public int getStartIndex2() {
 		return startIndex2;
 	}
 
+	public void setStartIndex2(int startIndex2) {
+		this.startIndex2 = startIndex2;
+	}
+
 	public int getEndIndex2() {
 		return endIndex2;
+	}
+
+	public void setEndIndex2(int endIndex2) {
+		this.endIndex2 = endIndex2;
 	}
 
 	public int getStartLine1() {
 		return startLine1;
 	}
 
+	public void setStartLine1(int startLine1) {
+		this.startLine1 = startLine1;
+	}
+
 	public int getEndLine1() {
 		return endLine1;
+	}
+
+	public void setEndLine1(int endLine1) {
+		this.endLine1 = endLine1;
 	}
 
 	public int getStartLine2() {
 		return startLine2;
 	}
 
+	public void setStartLine2(int startLine2) {
+		this.startLine2 = startLine2;
+	}
+
 	public int getEndLine2() {
 		return endLine2;
+	}
+
+	public void setEndLine2(int endLine2) {
+		this.endLine2 = endLine2;
 	}
 
 	public int getMappedCountableStmtCount() {
 		return mappedCountableStatement;
 	}
+
+	public void setMappedCountableStmtCount(int mappedCountableStatement) {
+		this.mappedCountableStatement = mappedCountableStatement;
+	}	
 
 	public int getMappedNonCountableStmtCount() {
 		return mappedNonCountableStatement;
@@ -98,4 +134,17 @@ public class Mapping {
 		this.mappedNonCountableStatement = mappedNonCountableStatement;
 		this.isPlagMapping = isPlagMapping;
 	}
+
+	@Override
+	public String toString() {
+		String mapping = "";
+		mapping = mapping + String.format("Start idx 1: %d, end idx 1: %d || Start idx 2: %d, end idx 2: %d %n ", startIndex1, endIndex1, startIndex2, endIndex2);
+		mapping = mapping + String.format("Start line 1: %d, End line 1: %d || Start line 2: %d, end line 2: %d %n ", startLine1, endLine1, startLine2, endLine2);
+		mapping = mapping + String.format("Mapped countable stmt: %d %n", mappedCountableStatement);
+		mapping = mapping + String.format("Mapped NON-countable stmt: %d %n", mappedNonCountableStatement);
+		mapping = mapping + String.format("isPlagMapping: %s %n", isPlagMapping);
+		return mapping;
+	}
+
+	
 }

--- a/lib/java/PlagiarismDetection/src/pd/utils/Mappings/SkeletonMapping.java
+++ b/lib/java/PlagiarismDetection/src/pd/utils/Mappings/SkeletonMapping.java
@@ -1,0 +1,58 @@
+package pd.utils.Mappings;
+
+public class SkeletonMapping {
+  private int startLine1, endLine1, startLine2, endLine2;
+  private long submissionSimilarityMappingId;
+
+  public SkeletonMapping() {
+  }
+
+  public SkeletonMapping(int startLine1, int endLine1, int startLine2, int endLine2) {
+    this.startLine1 = startLine1;
+    this.endLine1 = endLine1;
+    this.startLine2 = startLine2;
+    this.endLine2 = endLine2;
+  }
+
+  public int getStartLine1() {
+    return startLine1;
+  }
+
+  public void setStartLine1(int startLine1) {
+    this.startLine1 = startLine1;
+  }
+
+  public int getEndLine1() {
+    return endLine1;
+  }
+
+  public void setEndLine1(int endLine1) {
+    this.endLine1 = endLine1;
+  }
+
+  public int getStartLine2() {
+    return startLine2;
+  }
+
+  public void setStartLine2(int startLine2) {
+    this.startLine2 = startLine2;
+  }
+
+  public int getEndLine2() {
+    return endLine2;
+  }
+
+  public void setEndLine2(int endLine2) {
+    this.endLine2 = endLine2;
+  }
+
+  public long getSubmissionSimilarityMappingId() {
+    return submissionSimilarityMappingId;
+  }
+
+  public void setSubmissionSimilarityMappingId(long submissionSimilarityMappingId) {
+    this.submissionSimilarityMappingId = submissionSimilarityMappingId;
+  }
+
+  
+}

--- a/lib/java/PlagiarismDetection/src/pd/utils/Tokens/TokenList.java
+++ b/lib/java/PlagiarismDetection/src/pd/utils/Tokens/TokenList.java
@@ -23,8 +23,10 @@ public class TokenList extends ArrayList<TokenSSID> {
 
 	private static final long serialVersionUID = 1791998687760639392L;
 	private boolean[] markedTokens = null;
+	private Boolean[] markedBaseTokens = null;
 	private ArrayList<Integer> startOfStmtTokenIndices = new ArrayList<Integer>();
 	private int markedTokenCount = 0;
+	private int baseTokenCount = 0; // number of skeleton code tokens
 
 	public void markRange(int start, int end) {
 		if (start >= size()) {
@@ -61,8 +63,14 @@ public class TokenList extends ArrayList<TokenSSID> {
 			markedTokens = new boolean[size()];
 		}
 
+		if (markedBaseTokens == null) {
+			markedBaseTokens = new Boolean[size()];
+		}
+
 		for (int i = start; i <= end; i++) {
 			markedTokens[i] = true;
+			markedBaseTokens[i] = Boolean.TRUE;
+			baseTokenCount++;
 		}
 	}
 
@@ -84,6 +92,14 @@ public class TokenList extends ArrayList<TokenSSID> {
 		return markedTokenCount;
 	}
 
+	public int getBaseCount() {
+		return baseTokenCount;
+	}
+
+	public Boolean[] getMarkedBaseTokens() {
+		return markedBaseTokens;
+	}
+
 	public boolean isTokenMarked(int index) {
 		if (markedTokens == null) {
 			return false;
@@ -93,6 +109,17 @@ public class TokenList extends ArrayList<TokenSSID> {
 
 	public void unmarkAll() {
 		markedTokens = null;
+		markedBaseTokens = null;
 		markedTokenCount = 0;
+		baseTokenCount = 0;
+	}
+
+	@Override
+	public String toString() {
+		String tokenList = "";
+		for (int i = 0; i < this.size(); i++) {
+			tokenList = tokenList + this.get(i) + " ";
+		} 
+		return tokenList;
 	}
 }


### PR DESCRIPTION
A code mapping is a portion of code that is in common of 2 submissions.
This PR involves modifying how similarity percentage is computed and how to distinguish base code (skeleton code) vs submission code in a code mapping.

Currently, if the submissions contain base code, after obtaining all code mappings, PD engine will find base code within each code mapping. A count is obtained by original number of similar statements in the mapping - number of base codes' statements.

If this count is more than the MML threshold, all code tokens (including base tokens) will be counted in similarity percentage calculation and flag isPlagMapping marked as true. Otherwise, all tokens will be marked as part of base code and not counted in similarity percentage calculation; flag isPlagMapping marked as false.

The updated logic is as follows

After PD engine finds all base codes within the code mapping, tokens from base code will be marked as base tokens and be excluded from similarity percentage calculation. The rest of tokens from the code mapping will be marked as similar tokens. 
We also store information of base codes (start line, end line) within the code mapping.

The marking of flag  isPlagMapping remains the same.