### PR TITLE
Saving result to db

### DIFF
--- a/lib/java/PlagiarismDetection/src/Main.java
+++ b/lib/java/PlagiarismDetection/src/Main.java
@@ -22,9 +22,13 @@ import java.text.*;
 import pd.utils.*;
 import pd.*;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 public class Main {
 
 	public static final String SKELETON = "skeleton";
+
+	private static Logger logger = LogManager.getLogger();
 
 	// static final int KGRAM_SIZE = 3;
 
@@ -100,10 +104,22 @@ public class Main {
 			
 			System.out.println("[" + dateFormat.format(new java.util.Date()) + "] Starting upload to database...");
 
+			long beforeInsertDB = System.nanoTime();
+
+			long countCodeMappings = 0L;
+			for (Result result : simResults) {
+			  long nbrOfCodeMappings = result.getCodeIndexMappings().size();
+				countCodeMappings += nbrOfCodeMappings;
+			}
+			logger.info("Before saving result to db: assignmentId = {}, nbr of submissions = {}, nbr of code mappings = {}", aId, submissions.size(), countCodeMappings);
+
 			MySQLDB.getMySQLDB().insertIntoDB(aId, submissions, simResults);
 			
 			System.out.println("[" + dateFormat.format(new java.util.Date()) 
           + "] Plagarism detection completed upload to database");
+
+			long afterInsertDB = System.nanoTime();
+			logger.info("Saving to DB took: {}s", (afterInsertDB - beforeInsertDB) / Math.pow(10, 9)); 
 		  
 		} catch (Exception ex) {
 			System.out.println(ex.getMessage());

--- a/lib/submissions_handler.rb
+++ b/lib/submissions_handler.rb
@@ -152,7 +152,7 @@ module SubmissionsHandler
 	  password = config[Rails.env]["password"]
 
     # Run the java program and get its pid
-    command = %Q{java -Xmx1024M -Dlog4j2.configurationFile="#{Rails.application.config.plagiarism_detection_log_configuration_path}" -jar "#{Rails.application.config.plagiarism_detection_path}" } + 
+    command = %Q{java -Xmx2048M -Dlog4j2.configurationFile="#{Rails.application.config.plagiarism_detection_log_configuration_path}" -jar "#{Rails.application.config.plagiarism_detection_path}" } + 
               %Q{#{assignment.id} #{compare_dir} #{assignment.language.downcase} } +
               %Q{#{assignment.min_match_length} #{assignment.ngram_size} } +
               %Q{#{host} #{database} #{username} #{password} #{isMapEnabled}}


### PR DESCRIPTION
The bottleneck of saving similarity results to DB falls into saving code mappings. This PR updates the way mapping records are saved by sending batches in smaller sizes and by setting up connection properties to allow SQL queries' optimization.

![saving-results](https://user-images.githubusercontent.com/5399322/163801196-520d1cba-0c4d-4128-b059-6ffcffdff673.png)

Resolves #123 


