### PR TITLE
submission count is 0 for some zip file from Mac

### DIFF
--- a/lib/submissions_handler.rb
+++ b/lib/submissions_handler.rb
@@ -81,9 +81,30 @@ module SubmissionsHandler
     # Add filters for file types
     accepted_formats = [".py",".java", ".cpp", ".c", ".h", ".scala", ".m", ".ml", ".mli", ".r"]
 
+    # check zip file from Mac
+    zip_from_Mac = false
+    has_entry_same_name_with_upload_file = false
+    upload_file_without_ext = File.basename(upload_file, ".zip") + File::SEPARATOR
+
     # Extract submissions into dir
     Zip::File.open(upload_file) { |zip_file|
       zip_file.each { |f|
+
+      file_entry_names = zip_file.entries.collect {|file| file.name}
+      file_entry_names.each { |file_name|
+        if (file_name.eql?(upload_file_without_ext)) 
+          has_entry_same_name_with_upload_file = true
+        end
+
+        if (file_name.include?("__MACOSX")) 
+          zip_from_Mac = true
+        end
+      }
+
+      if (zip_from_Mac and has_entry_same_name_with_upload_file) 
+        return false
+      end
+
       # isdirectory or filter by accepted file extension
       if File.directory?(f.name) or accepted_formats.include? File.extname(f.name)
         upload_log << %Q{[#{Time.now.in_time_zone}] Extracting #{f.name}}


### PR DESCRIPTION
Resolve #114 

Sometimes zip file from Mac resulted in 0 submission count. This was because end-users zipped the whole folder instead of selecting all submissions' files/ folders to zip. This PR aims to prevent users from creating an assignment when their assignment file was not compressed in a recommended way.

![image](https://user-images.githubusercontent.com/5399322/163981022-e80030fe-2a38-4c27-86af-89ee95f2bf8f.png)
