### PR TITLE
Edit show.html.erb

### DIFF
--- a/app/views/submission_similarities/show.html.erb
+++ b/app/views/submission_similarities/show.html.erb
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="table-container mt-3">
-    <table id="matchingStatementsTable" class="lines">
+    <table id="matchingStatementsTable" class="lines collapse show">
       <thead>
         <tr>
           <th class="lines_col">Submission by <%= @student1.id_string %></th>


### PR DESCRIPTION
Edit show.html.erb: initialize table class as "lines collapse show" instead of "lines"

Original class definition causes the first press of the button to change class to "lines collapse show", resulting in unreactive visuals.

Changing the class to "lines collapse show" instead allows the first press of the button to change the class to "lines collapse", which is reactive.

Helps to resolve issue https://github.com/WING-NUS/SSID/issues/149 partially

Before:
![before](https://user-images.githubusercontent.com/24633766/173013089-79190048-188a-409d-a5ba-38550a2a3ff7.gif)

After:
![after](https://user-images.githubusercontent.com/24633766/173013100-7cd4fe21-1917-4996-8e9d-f8025f0577de.gif)

