### PR TITLE
Fix update course user redirect

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -193,7 +193,7 @@ class Admin::UsersController < ApplicationController
     # Check for errors and render view
     if @the_user.errors.empty?
       if @course
-        redirect_to admin_users_url, notice: "#{@course.code} User was successfully updated."
+        redirect_to course_users_url(@course), notice: "#{@course.code} User was successfully updated."
       else
         redirect_to admin_users_url, notice: "Admin User was successfully updated."
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -217,10 +217,12 @@ class Admin::UsersController < ApplicationController
       
       # redirect link accordingly depending on whether user is admin or teaching staff
       @user = User.find_by_id(session[:user_id]) 
-      url = admin_users_url
-      if (!@user.is_admin)
-        url = course_users_url(course)
-      end
+      # url = admin_users_url
+
+      # if (!@user.is_admin)
+      #   url = course_users_url(course)
+      # end
+      url = course_users_url(course)
       
       if membership && membership.role == UserCourseMembership::ROLE_GUEST && guest.destroy && membership.destroy 
         redirect_to url, notice: "User was removed from #{course.code}."
@@ -231,7 +233,7 @@ class Admin::UsersController < ApplicationController
       end
     else
       if @the_user.destroy
-        redirect_to admin_users_url, notice: 'User was successfully deleted.'
+        redirect_to url, notice: 'User was successfully deleted.'
       else
         redirect_to admin_users_url, alert: @the_user.errors.to_a.join(", ")
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -226,10 +226,17 @@ class Admin::UsersController < ApplicationController
         redirect_to url, alert: "Error removing user"
       end
     else
-      if @the_user.destroy
-        redirect_to url, notice: 'User was successfully deleted.'
+      if @the_user.is_admin
+        if @the_user.destroy
+          redirect_to admin_users_url, notice: 'User was successfully deleted.'
+        else
+          redirect_to admin_users_url, alert: @the_user.errors.to_a.join(", ")
+        end
       else
-        redirect_to admin_users_url, alert: @the_user.errors.to_a.join(", ")
+        if @the_user.destroy
+          redirect_to url, notice: 'User was successfully deleted.'
+        end
+        redirect_to url, alert: @the_user.errors.to_a.join(", ")
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -215,13 +215,7 @@ class Admin::UsersController < ApplicationController
       membership = course.membership_for_user(@the_user)
       guest = course.guest_user_finder(@the_user)
       
-      # redirect link accordingly depending on whether user is admin or teaching staff
-      @user = User.find_by_id(session[:user_id]) 
-      # url = admin_users_url
-
-      # if (!@user.is_admin)
-      #   url = course_users_url(course)
-      # end
+      # Redirect current user back to the course users page
       url = course_users_url(course)
       
       if membership && membership.role == UserCourseMembership::ROLE_GUEST && guest.destroy && membership.destroy 


### PR DESCRIPTION
Edit admin/user_controller.rb redirect code to lead users back to course users page after editing or deleting course users. Does not include guests.

Original redirect links cause edits and deleting to redirect back to all users' page.

Changing redirect address to point to course users fixes this issue.

Helps to resolve  #177 and #174 

# Before edits:

## Editing user
![fix_redirect_edit_before_fix](https://user-images.githubusercontent.com/24633766/174784824-37bd36d4-8fce-4012-baaf-a6389f05ec92.gif)
## Deleting user
![fix_redirect_delete_before_fix](https://user-images.githubusercontent.com/24633766/174784800-b6d6a212-3380-47eb-8106-fc9ea714ab48.gif)


# After edits:
## Editing user
![fix_redirect_edit_fix](https://user-images.githubusercontent.com/24633766/174784916-bf8575af-ff9a-4f03-be52-863c465e7af7.gif)
## Deleting user
![fix_redirect_delete_fix](https://user-images.githubusercontent.com/24633766/174784893-face734d-85f9-4265-b2be-2f22fafbc8c1.gif)

