### PR TITLE
fix types of some tokens when translating from ANTLR tokens to SSID tokens

### DIFF
--- a/lib/antlr/grammars/bin/cpp/cpp_token_mappings
+++ b/lib/antlr/grammars/bin/cpp/cpp_token_mappings
@@ -130,7 +130,7 @@ Semi,Symbol
 Dot,Symbol
 DotStar,Symbol
 Ellipsis,Symbol
-Identifier,Symbol
+Identifier,Variable
 Integerliteral,Constant
 Decimalliteral,Constant
 Octalliteral,Constant

--- a/lib/antlr/grammars/bin/python3/python3_token_mappings
+++ b/lib/antlr/grammars/bin/python3/python3_token_mappings
@@ -37,7 +37,7 @@ BREAK,Keyword
 ASYNC,Keyword
 AWAIT,Keyword
 NEWLINE,Ignore
-NAME,Keyword
+NAME,Variable
 STRING_LITERAL,Constant
 BYTES_LITERAL,Constant
 DECIMAL_INTEGER,Constant


### PR DESCRIPTION
SSID was not able to detect some similar codes in Python and C++ languages. It was due to mistranslation of some token types when translating from ANTLR tokens to SSID tokens. This PR aims to cover the fix in Python and C++.