### PR TITLE
Add admin signup console

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -226,3 +226,8 @@ ol.breadcrumb {
     }
   }
 }
+
+div.notice {
+  margin-bottom: $spacer;
+  color: rgb(0, 160, 0);
+}

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -149,6 +149,15 @@ class Admin::UsersController < ApplicationController
     end
   end
 
+  def approve
+    @the_user = User.find(params[:user_id])
+    @the_user.update_attribute(:is_admin_approved, true)
+    @the_user.save
+    redirect_to admin_users_url, notice: 'User was successfully approved.'
+  end
+
+
+
   # PUT /admin/users/1
   def update
     @the_user = User.find(params[:id])
@@ -245,9 +254,10 @@ class Admin::UsersController < ApplicationController
         end
       else
         if @the_user.destroy
-          redirect_to url, notice: 'User was successfully deleted.'
+          redirect_to admin_users_url, notice: 'User was successfully deleted.'
+        else
+          redirect_to admin_users_url, alert: @the_user.errors.to_a.join(", ")
         end
-        redirect_to url, alert: @the_user.errors.to_a.join(", ")
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -37,8 +37,12 @@ class Admin::UsersController < ApplicationController
   def index
     @admins = User.where(is_admin: true)
 
+    @signups = User.where(is_admin_approved: false)
+
     # users don't belong to any course
-    @loners = User.all - User.joins(:memberships) - @admins
+    @loners = User.all - User.joins(:memberships) - @admins - @signups
+
+    
   end
 
   # GET /admin/users/new

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,11 +27,11 @@ class SessionsController < ApplicationController
   #orRgKyGUs7cz
   def create
     user = User.find_by_name(params[:name])
-    if user and user.authenticate(params[:password])
+    if user and user.authenticate(params[:password]) and user.is_admin_approved
       session[:user_id] = user.id
       redirect_to root_url
     else
-      redirect_to login_url, alert: "Invalid user/password combination"
+      redirect_to login_url, alert: "Invalid user/password combination or user account not approved by admin"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
     @user.id_string = @user.name
     if @user.save
       # @user.send_activation_email
-      flash[:info] = "Please check your email to activate your account."
+      flash[:notice] = "Please check your email to activate your account."
       redirect_to root_url
     else
       render 'new'

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -93,8 +93,56 @@
 </div>
 <% end %>
 
+<% unless @signups.empty? %>
+<div class="new_users_section">
+
+  <h5>New User Signups</h5>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Full Name/ Hash</th>
+        <th class="id_col">Login/ Hash</th>
+        <th class="id_col">ID/ Hash</th>
+        <th class="actions_col">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @signups.each { |user| %>
+        <tr>
+          <td><%= user.full_name || "--" %></td>
+          <td><%= user.name %></td>
+          <td><%= user.id_string %></td>
+          <td>
+            <div class="dropdown">
+              <a data-toggle="dropdown" id="loneUserDropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+                <%= image_tag("more_vert_black_24dp.svg", alt: "Lone Users Menu Dropdown")%>        
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="loneUserDropdownMenuLink">
+                <li><%= link_to "Edit", edit_admin_user_url(user), class: 'dropdown-item' %></li>
+                <li>
+                  <%= button_tag 'Delete', class: "dropdown-item", data: { 'bs-toggle' => "modal", 'bs-target' => "#deleteUserModal", 'bs-url' => "#{admin_user_url(user)}" } %>
+                </li>
+                <li>
+                  <%= button_tag 'Approve', class: "dropdown-item", data: { 'bs-toggle' => "modal", 'bs-target' => "#approveUserModal", 'bs-url' => "#{admin_user_url(user)}" } %>
+                </li>
+              </ul>
+            </div>
+          </td>          
+        </tr>
+      <% } %>
+    </tbody>
+  </table>
+</div>
+<% end %>
+
 <div class="modal fade" id="deleteUserModal" tabindex="-1" role="dialog" aria-hidden="true">
   <% @modal = SiteModal.new("Delete User", "The user will be permanently deleted. Are you sure?", { :name => "OK", :method => :delete }) %>
+  <%= render partial: "site/modal", locals: { modal: @modal }%>
+</div>
+
+<div class="modal fade" id="approveUserModal" tabindex="-1" role="dialog" aria-hidden="true">
+  <% @modal = SiteModal.new("Approve User", "The user will be approved. Are you sure?", { :name => "OK", :method => :approve }) %>
   <%= render partial: "site/modal", locals: { modal: @modal }%>
 </div>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -124,7 +124,7 @@
                   <%= button_tag 'Delete', class: "dropdown-item", data: { 'bs-toggle' => "modal", 'bs-target' => "#deleteUserModal", 'bs-url' => "#{admin_user_url(user)}" } %>
                 </li>
                 <li>
-                  <%= button_tag 'Approve', class: "dropdown-item", data: { 'bs-toggle' => "modal", 'bs-target' => "#approveUserModal", 'bs-url' => "#{admin_user_url(user)}" } %>
+                  <li><%= link_to "Approve", admin_user_approve_user_url(user), class: 'dropdown-item' %></li>
                 </li>
               </ul>
             </div>
@@ -138,11 +138,6 @@
 
 <div class="modal fade" id="deleteUserModal" tabindex="-1" role="dialog" aria-hidden="true">
   <% @modal = SiteModal.new("Delete User", "The user will be permanently deleted. Are you sure?", { :name => "OK", :method => :delete }) %>
-  <%= render partial: "site/modal", locals: { modal: @modal }%>
-</div>
-
-<div class="modal fade" id="approveUserModal" tabindex="-1" role="dialog" aria-hidden="true">
-  <% @modal = SiteModal.new("Approve User", "The user will be approved. Are you sure?", { :name => "OK", :method => :approve }) %>
   <%= render partial: "site/modal", locals: { modal: @modal }%>
 </div>
 

--- a/app/views/layouts/cover.html.erb
+++ b/app/views/layouts/cover.html.erb
@@ -1,4 +1,9 @@
 <div class="site-cover">
+  <% if flash[:notice] %>
+    <div class="notice">
+      <%= flash[:notice] %>
+    </div>
+  <% end %>
   <div class="site-introduction">
     <p class="site-motto text-dark">Empowering the next generations of programmers.</p>
     <div class="site-clip">

--- a/app/views/users/_signup_form.html.erb
+++ b/app/views/users/_signup_form.html.erb
@@ -19,6 +19,10 @@
     <%= f.text_field :name, class: "form-control" %>
   </div>
   <div>
+    <%= f.label :email, "Email", class: "form-label" %>
+    <%= f.text_field :email, class: "form-control" %>
+  </div>
+  <div>
     <%= f.label :password, class: "form-label" %>
     <%= f.password_field :password, class: "form-control" %>
   </div>

--- a/app/views/users/_signup_form.html.erb
+++ b/app/views/users/_signup_form.html.erb
@@ -5,7 +5,9 @@
 
       <ul>
       <% @user.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
+        <% if not msg.include? "Id string" %>
+          <li><%= msg %></li>
+        <% end %>
       <% end %>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,9 @@ SSID::Application.routes.draw do
   resources :announcements
 
   namespace :admin do
-    resources :users
+    resources :users do
+      get 'approve' => 'users#approve', :as => 'approve_user'
+    end
   end
   resources :users
   

--- a/db/migrate/20220914074730_add_admin_approved_to_users.rb
+++ b/db/migrate/20220914074730_add_admin_approved_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminApprovedToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :is_admin_approved, :boolean, default: false
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,5 +22,6 @@ admin = User.new { |user|
   user.password_digest = BCrypt::Password.create('$$SSIDPassword$$')
   user.email = "adminemail@testmail.com"
   user.is_admin = true
+  user.is_admin_approved = true
 }
 admin.save

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,6 +20,7 @@ admin = User.new { |user|
   user.name = "admin"
   user.full_name = "SSID Administrator"
   user.password_digest = BCrypt::Password.create('$$SSIDPassword$$')
+  user.email = "adminemail@testmail.com"
   user.is_admin = true
 }
 admin.save


### PR DESCRIPTION
Allow admin to approve users before they can login.
---
After user signs up:
![image](https://user-images.githubusercontent.com/24633766/191265949-9a15e31c-18b7-4512-bd9d-dde016c8b6b1.png)
If users attempt to login without admin approval
![image](https://user-images.githubusercontent.com/24633766/191266030-84a1b8b7-ea7e-4693-b821-c802471ca297.png)
Admin screen after user signs up, with approve in drop down
![image](https://user-images.githubusercontent.com/24633766/191266346-37de1366-64ab-4c36-a150-9a83d246d425.png)
After admin clicks approve
![image](https://user-images.githubusercontent.com/24633766/191266459-23864f82-9077-4466-9be9-cce0dd5845ed.png)
