### PR TITLE
Fix Safari print JS

### DIFF
--- a/app/views/submission_similarities/_pair_report.html.erb
+++ b/app/views/submission_similarities/_pair_report.html.erb
@@ -55,5 +55,7 @@
 </div>
 
 <script type="text/javascript">
+$(document).ready(function() {
   window.print();
+});
 </script>


### PR DESCRIPTION
Due to Safari's JavaScript handling which differs from Firefox and Chrome/ Chromium-based browsers, `window.print()` is called prematurely before line numbers and code display finish rendering.
Current:
![Screenshot 2022-09-28 at 4 44 47 PM](https://user-images.githubusercontent.com/29513997/192733273-47852a54-9d27-44a4-b3c4-41b96ac060a8.png)

Fixed:
![Screenshot 2022-09-28 at 4 43 45 PM](https://user-images.githubusercontent.com/29513997/192733313-9b876b05-9abc-41d6-80b2-46d18174eba7.png)
