### PR TITLE
Allow instructors to create courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -16,9 +16,9 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
 =end
 
 class CoursesController < ApplicationController
-  # before_action { |controller|
-  #   controller.send :authenticate_actions_for_admin, only: [ :new, :create, :edit, :update, :destroy ]
-  # }
+  before_action { |controller|
+    controller.send :authenticate_actions_for_admin, only: [ :destroy ]
+  }
   before_action { |controller|
     if params[:course_id]
       @course = Course.find(params[:course_id])

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -16,9 +16,9 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
 =end
 
 class CoursesController < ApplicationController
-  before_action { |controller|
-    controller.send :authenticate_actions_for_admin, only: [ :new, :create, :edit, :update, :destroy ]
-  }
+  # before_action { |controller|
+  #   controller.send :authenticate_actions_for_admin, only: [ :new, :create, :edit, :update, :destroy ]
+  # }
   before_action { |controller|
     if params[:course_id]
       @course = Course.find(params[:course_id])
@@ -72,11 +72,26 @@ class CoursesController < ApplicationController
       expiry_date = expiry_time.to_date
       c.expiry = Time.zone.local_to_utc(DateTime.new(expiry_date.year, expiry_date.month, expiry_date.mday, expiry_time.hour, expiry_time.min))
     }
+
     
     if @course.errors.empty? and @course.save
-      redirect_to courses_url, notice: 'Course was successfully created.'
+      
     else
       render action: "new"
+    end
+
+    if not @user.is_admin
+      @membership = UserCourseMembership.new { |m|
+        m.user = @user
+        m.course = @course
+        m.role = UserCourseMembership::ROLE_TEACHING_STAFF
+      }
+
+      if @membership.errors.empty? and @membership.save
+        redirect_to courses_url, notice: 'Course was successfully created.'
+      else
+        render action: "new"
+      end
     end
   end
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -16,9 +16,7 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
 %>
 <header class="course_header">
   <h4>Courses</h4>
-  <% if @user.is_admin %>
-    <%= link_to image_tag("add_circle_outline_blue_24dp.svg", size: "28", alt: "New Course"), new_course_url, {'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'New Course'} %>
-  <% end %>  
+  <%= link_to image_tag("add_circle_outline_blue_24dp.svg", size: "28", alt: "New Course"), new_course_url, {'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => 'New Course'} %>
 </header>
 
 <% if flash[:notice] %>


### PR DESCRIPTION
# This update allows instructors to be able to create courses once approved by admin.

Instructor's view of courses page once logged in. The add course functionality has been enabled for users approved by the admin.
![image](https://user-images.githubusercontent.com/24633766/195108374-b3895642-d155-4937-9780-49185dc0312e.png)

Subsequent add course function still the same process as admin, but now if a non admin creates a course, the user is automatically added as an instructor in the membership model.
User will automatically appear in recently created course.
![image](https://user-images.githubusercontent.com/24633766/195109020-419a7b16-e985-4612-aa76-3d3d593e29ae.png)

