### PR TITLE
Add Antlr to ant javac

### DIFF
--- a/doc/add_support_for_new_language.md
+++ b/doc/add_support_for_new_language.md
@@ -75,10 +75,7 @@ Antlr4Grammars.lang
       return lexer;
     }
     </pre>
-14. Run "ant"
-
-> Remember to add ANTLR to your CLASSPATH environmental variable before running it
-
+14. Run "ant" to rebuild.
 
 15. Now navigate to `/app/models/assignment.rb` and add the respective language name under `LANGUAGES` & `PRETTIFY_LANGUAGES`
 

--- a/lib/java/PlagiarismDetection/build.xml
+++ b/lib/java/PlagiarismDetection/build.xml
@@ -14,7 +14,7 @@
 
   <target name="compile">
     <mkdir dir="${classes.dir}"/>
-    <javac srcdir="${src.dir}" destdir="${classes.dir}" debug="true" debuglevel="lines,vars,source" classpath="${classpath.dir}/snakeyaml-1.10.jar;${classpath.dir}/log4j-api-2.17.2.jar;${classpath.dir}/log4j-core-2.17.2.jar">
+    <javac srcdir="${src.dir}" destdir="${classes.dir}" debug="true" debuglevel="lines,vars,source" classpath="${classpath.dir}/snakeyaml-1.10.jar;${classpath.dir}/log4j-api-2.17.2.jar;${classpath.dir}/log4j-core-2.17.2.jar;${classpath.dir}/antlr-4.8-complete.jar">
       <compilerarg value="-Xlint:unchecked"/>
     </javac>
   </target>


### PR DESCRIPTION
Antlr is missing in `<javac/>` in `build.xml` so it's not added to the build when `ant` is run. I fixed it by adding Antlr to there. We don't need to manually add Antlr to environment classpath anymore as in the previous doc. 