### PR TITLE
Enable skip confirmation when seeding

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,16 +16,16 @@ along with SSID.  If not, see <http://www.gnu.org/licenses/>.
 =end
 
 # Create default admin user
-admin = User.new { |user|
-  user.name = "admin"
+admin = User.new do |user|
+  user.name = "admin123"
   user.full_name = "SSID Administrator"
-  user.password = "SSIDPassword"
-  user.password_confirmation = "SSIDPassword"
-  user.email = "ssidadmin@example.com"
+  user.password = "SSIDPassword123!"
+  user.password_confirmation = "SSIDPassword123!"
+  user.email = "ssidadmin123@example.com"
   user.is_admin = true
   user.is_admin_approved = true
   user.confirmed_at = Time.zone.now
   user.confirmation_sent_at = Time.zone.now
-
-}
+end
+admin.skip_confirmation! # Used to confirm account when seeding a user to bypass user.confirmed? check
 admin.save


### PR DESCRIPTION
Fix #298

Summary of changes:
1. Adding `skip_confirmation!` to `seeds.rb` as mentioned by the resources from @sibinhho99 and @huyuxin0429 Since our implementation with Devise for authentication and email confirmation will check for `user.confirmed?`, however during development we will need to login with fake admin account, hence will not be able to confirm the email.
2. Changing the password to `SSIDPassword123!` since the Devise authentication also check for valid password by having at least one uppercase, one lowercase, a number and a special character.
3. Changes to other fields such as name and email just to standardize with the new password.