### PR TITLE
Update Beginner Docs for WSL Support

### DIFF
--- a/README-v-Beginner.md
+++ b/README-v-Beginner.md
@@ -4,7 +4,7 @@
 
 **Guide in One Paragraph**: This is an installation guide for those who have limited knowledge of Linux. This guide assumes only limited fluency with `bash`,  `tmux`, and `conda`.  This guide wishes to save your time by telling you the trick in critical steps. 
 
-Last update: 18th March 2021 (pre-dockerized configuration)
+Last update: 18th September 2023 (pre-dockerized configuration)
 
 ## Package Installation
 
@@ -39,6 +39,16 @@ https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on
 
 ### Ruby v2.6.6. ; bundler v2.1.4
 
+(Newer Update): If you are using Ubuntu 22.04 (LTS), you may benefit from following the steps specified in the following link:
+
+```
+https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-ubuntu-22-04
+```
+
+Complete the installation up to the following step: `echo "gem: --no-document" > ~/.gemrc`, then proceed to the "installing bundler" section.
+
+(Older Update: Ubuntu 18.04)
+
 I had a hard time installing `Ruby v2.6.6`., which was the current version at the time of writing this installation guide. 
 
 I forgot my specific steps, but these tips are useful:
@@ -72,6 +82,8 @@ A successful installation may follow these steps:
 ```
 https://rubygems.org/gems/bundler/versions/2.1.4
 ```
+
+### Installing Bundler
 
 Make sure to follow these commands:
 
@@ -128,8 +140,6 @@ Please `mysql -u root -p` to try to login into `root` to see if the password is 
 
 ## TroubleShooting
 
-###
-
 ### libmysqlclient.so error
 
 This error occurs when doing `bundle install`, specifically with installing the `rugged` gem.
@@ -153,6 +163,35 @@ sudo apt-get install libmysqlclient-dev
 ```
 
 Then re-run `bundle install`. This should do the trick.
+
+
+### MySQL: Error 1045
+
+You might encounter the following error when using MySQL:
+
+```
+ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)
+```
+
+In this case, most likely you have entered a wrong password that is different from what you set during the MySQL installation for the root user.
+
+If you have forgotten the password, you may follow the instruction below:
+
+### MySQL: Update Password
+
+You can refer to the following instruction to change the root password:
+
+```
+https://docs.rackspace.com/docs/reset-a-mysql-root-password
+```
+
+Alternatively, if everything else fails, you can remove MySQL DB and install it again, should you don't have any crucial data that is stored in MySQL (noting that you have recently installed...)
+
+You can refer to the following guide:
+
+```
+https://linuxgenie.net/uninstall-mysql-from-ubuntu/
+```
 
 ## Final Words
 

--- a/README-v-Beginner.md
+++ b/README-v-Beginner.md
@@ -17,6 +17,16 @@ Make sure to install all packages in the version as **exactly** specified in the
 
 Yisong's config: a standard Ubuntu 18.04 version Linux.
 
+## WSL Support
+
+For Windows Users who are not planning to do a dual-boot on their computer, WSL works just as well for most of the SSID operations. You can refer to the following link on how to setup Ubuntu with WSL on your computer.
+
+https://learn.microsoft.com/en-us/windows/wsl/install
+
+Our recommended method is to activate WSL and then install an Ubuntu distribution from the Microsoft Store. Current SSID supports Ubuntu 22.04 (LTS).
+
+For those who are using WSL, you might find that some of the commands provided in the below tutorials are rather Linux specific (e.g. `sudo systemctl start <SERVICE_NAME>`). On our case, if you are using WSL, you might find that the syntax might be different (e.g. `sudo service <SERVICE_NAME> start`). Do adjust accordingly.
+
 ### Java 11
 
 No difficulty installing `Java 11`. 
@@ -90,6 +100,13 @@ The last package actually takes a significant time to properly install and confi
 https://phoenixnap.com/kb/how-to-install-mysql-on-ubuntu-18-04
 ```
 
+Alternatively, you may also want to refer to the following instruction:
+
+https://www.digitalocean.com/community/tutorials/how-to-install-mysql-on-ubuntu-22-04
+
+This will provide a better instruction for Ubuntu 22.04 (LTS) users.
+
+
 Step 2 in this tutorial is very critical for Linux users. 
 
 🎉🎉🎉 Congratulations! You have successfully installed all packages!
@@ -108,6 +125,34 @@ The `root` MySQL user password is different from what we key in the SSID config 
 Please `mysql -u root -p` to try to login into `root` to see if the password is correct. 
 
 🎉🎉🎉 All done!
+
+## TroubleShooting
+
+###
+
+### libmysqlclient.so error
+
+This error occurs when doing `bundle install`, specifically with installing the `rugged` gem.
+
+Exact Error Message:
+
+```
+LoadError: libmysqlclient.so.21: cannot open shared object file: No such file or directory - /root/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/mysql2-0.5.3/lib/mysql2/mysql2.so
+/mnt/c/Users/Jason C/Code/SSID/config/application.rb:7:in `<top (required)>'
+/mnt/c/Users/Jason C/Code/SSID/rakefile:4:in `require_relative'
+/mnt/c/Users/Jason C/Code/SSID/rakefile:4:in `<top (required)>'
+(See full trace by running task with --trace)
+```
+
+Suggested solution:
+
+Install the `libmysqlclient.so` MySQL Client Library by running the following command:
+
+```
+sudo apt-get install libmysqlclient-dev
+```
+
+Then re-run `bundle install`. This should do the trick.
 
 ## Final Words
 


### PR DESCRIPTION
Update the beginner docs to include a troubleshooting section for MySQL and Gem installations, as well as support for Ubuntu 22.04 and WSL users for onboarding.

## Description
I included the following additional sections in the beginner README file that caters the following:
- Changing the last updated date of the README file
- Add links relevant to Ubuntu 22.04 installation
- Add specific WSL guide
- Add troubleshooting section for MySQL and some gem installations

## Motivation and Context
Some of the past links might not be relevant to the new Ubuntu 22.04 currently in-use for WSL distributions. Furthermore, learning curve to setup MySQL is quite steep, hence providing with relevant resources that I used to setup the WSL environment (twice) might be helpful in addition to this 3-year old documentation.

## How Has This Been Tested?
N/A (no changes done aside from the markdown file changes)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
(by right, it is a Markdown change so I would assume that this follows the coding style)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
