### PR TITLE
Fix extra render when uploading invalid zip file

### DIFF
--- a/app/controllers/api/v1/assignments_controller.rb
+++ b/app/controllers/api/v1/assignments_controller.rb
@@ -135,7 +135,6 @@ module Api
             render json: { error: 'Value of studentSubmissions is not valid. ' \
                                   'studentSubmissions must be a valid zip file.' },
                    status: :bad_request
-            render action: 'new'
           end
         else
           render action: 'new'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes an extra `render` call

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[https://github.com/WING-NUS/SSID/issues/343](https://github.com/WING-NUS/SSID/issues/343)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Small bug which causes internal error when uploading invalid zip file instead of returning error message to the client

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
