### PR TITLE
Fix issue #370 SSID POST endpoints unable to work with Postman

### DIFF
--- a/app/controllers/api/v1/assignments_controller.rb
+++ b/app/controllers/api/v1/assignments_controller.rb
@@ -171,7 +171,7 @@ module Api
         # Valid zip file mime types that does not required to be further verified by the zip library
         if [X_ZIP_COMPRESSED_MIME_TYPE, ZIP_COMPRESSED_MIME_TYPE, APPLICATION_ZIP_MIME_TYPE,
             MULTIPART_X_ZIP_MIME_TYPE].include?(mime_type)
-          true
+          return true
         # Need to be further verified by zip library as it can be a rar file
         elsif mime_type == OCTET_STREAM_MIME_TYPE && opened_as_zip?(file_path)
           return true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the issue by adding an explicit `return` in the method to check uploaded file type. curl still works because it does not explicitly specify content type as in Postman. The method is from current web interface's code in `app/controllers/assignments_controller.rb`; not sure why there's a missing `return` (linter auto-correction bug or careless mistake).

Postman auto-detected my file type as `application/zip` (can be manually specified as well), which is in the current list of supported types, so there's no compatibility issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes [https://github.com/WING-NUS/SSID/issues/370](https://github.com/WING-NUS/SSID/issues/370)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing with Postman

## Screenshots (if appropriate):
<img width="879" alt="image" src="https://github.com/WING-NUS/SSID/assets/29513997/fd08179c-1649-468c-8f29-2aaacf504127">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
