### PR TITLE
Allow API keys of admin to access all courses

### DIFF
--- a/lib/api_keys_handler.rb
+++ b/lib/api_keys_handler.rb
@@ -38,6 +38,11 @@ module APIKeysHandler
   end
 
   def self.authorized_for_course?(user_id, course_id)
+    # Admins are allowed to access all courses
+    user = User.find(user_id)
+    if user.is_admin
+      return true
+    end
     user_course_membership = UserCourseMembership.find_by(user_id: user_id, course_id: course_id)
     user_course_membership.present?
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allows admins' API keys to access all courses

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#363 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently an admin user can view all courses in the web interface, so API keys belonging to such user should be able to access all courses as well

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing

## Screenshots (if appropriate):
[https://youtu.be/YT0tg4maf-w](https://youtu.be/YT0tg4maf-w)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
